### PR TITLE
Use dynamic github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
           git config --global user.name "1gtm"
@@ -89,8 +89,8 @@ jobs:
       - name: Release
         if: startsWith(github.event.issue.title, 'Release:') && contains(github.event.issue.html_url, '/pull/') && contains(github.event.issue.labels, 'locked') == false
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
         run: |


### PR DESCRIPTION
Switches CI workflows from a hardcoded `1gtm` user with `LGTM_GITHUB_TOKEN` to the dynamic `${{ github.actor }}` and the workflow's built-in `GITHUB_TOKEN`.

Mirrors https://github.com/kubedb/apimachinery/pull/1668.