### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha"]
+auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]

--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]
+auto_approve_usernames = ["tamalsaha", "1gtm", "1gtm-app[bot]"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,6 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Prepare git
         env:
           GITHUB_USER: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - name: Set up Go 1.25
@@ -99,12 +98,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
-          git config --global user.name "1gtm-app[bot]"
-          git config --global user.email "3686661+1gtm-app[bot]@users.noreply.github.com"
+          git config --global user.name "1gtm"
+          git config --global user.email "1gtm@appscode.com"
           git config --global \
             url."https://x-access-token:${GITHUB_TOKEN}@github.com".insteadOf \
             "https://github.com"
-          # git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Verify PR is from same repo (not a fork)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build
@@ -14,29 +11,12 @@ jobs:
       github.event.issue.pull_request != null &&
       startsWith(github.event.issue.title, 'Release:') &&
       !contains(github.event.issue.labels.*.name, 'locked') &&
-      (
-        contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association) ||
-        github.event.comment.user.login == '1gtm-app[bot]'
-      )
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-
-
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-
-      - name: Generate LGTM App token
-        id: lgtm-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
-          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: write
-          permission-pull-requests: write
 
       - name: Set up Go 1.25
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -98,17 +78,18 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
+          GITHUB_USER: 1gtm
+          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
         run: |
           git config --global user.name "1gtm"
           git config --global user.email "1gtm@appscode.com"
           git config --global \
-            url."https://x-access-token:${GITHUB_TOKEN}@github.com".insteadOf \
+            url."https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com".insteadOf \
             "https://github.com"
 
       - name: Verify PR is from same repo (not a fork)
         env:
-          GH_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
         run: |
           head_repo=$(gh pr view ${{ github.event.issue.number }} \
             --json headRepositoryOwner,headRepository \
@@ -120,8 +101,8 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_USER: x-access-token
-          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
+          GITHUB_USER: 1gtm
+          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,24 @@ name: Release
 on:
   issue_comment:
     types: [created]
-  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     name: Build
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.issue.title, 'Release:') &&
+      !contains(github.event.issue.labels.*.name, 'locked') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -76,13 +88,23 @@ jobs:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -x
           git config --global user.name "1gtm"
           git config --global user.email "1gtm@appscode.com"
           git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
+      - name: Verify PR is from same repo (not a fork)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          head_repo=$(gh pr view ${{ github.event.issue.number }} \
+            --json headRepositoryOwner,headRepository \
+            --jq '.headRepositoryOwner.login + "/" + .headRepository.name')
+          if [ "$head_repo" != "${{ github.repository }}" ]; then
+            echo "::error::PR head is $head_repo (fork); refusing to run release automation."
+            exit 1
+          fi
+
       - name: Release
-        if: startsWith(github.event.issue.title, 'Release:') && contains(github.event.issue.html_url, '/pull/') && contains(github.event.issue.labels, 'locked') == false
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go 1.25
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
           git config --global user.name "1gtm"
@@ -89,8 +89,8 @@ jobs:
       - name: Release
         if: startsWith(github.event.issue.title, 'Release:') && contains(github.event.issue.html_url, '/pull/') && contains(github.event.issue.labels, 'locked') == false
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         github.event.comment.user.login == '1gtm-app[bot]'
       )
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           git config --global user.name "1gtm"
           git config --global user.email "1gtm@appscode.com"
-          git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Verify PR is from same repo (not a fork)
         env:
@@ -111,7 +111,7 @@ jobs:
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
         run: |
-          title="${{ github.event.issue.title }}"
+          title="$PR_TITLE"
           while IFS=$': \r\t' read -r marker v ignored; do
               case $marker in
                   Release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,28 @@ jobs:
       github.event.issue.pull_request != null &&
       startsWith(github.event.issue.title, 'Release:') &&
       !contains(github.event.issue.labels.*.name, 'locked') &&
-      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+      (
+        contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association) ||
+        github.event.comment.user.login == '1gtm-app[bot]'
+      )
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
 
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Generate LGTM App token
+        id: lgtm-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Set up Go 1.25
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -85,16 +97,18 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
-          git config --global user.name "1gtm"
-          git config --global user.email "1gtm@appscode.com"
-          git remote set-url origin "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config --global user.name "1gtm-app[bot]"
+          git config --global user.email "3686661+1gtm-app[bot]@users.noreply.github.com"
+          git config --global \
+            url."https://x-access-token:${GITHUB_TOKEN}@github.com".insteadOf \
+            "https://github.com"
+          # git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Verify PR is from same repo (not a fork)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           head_repo=$(gh pr view ${{ github.event.issue.number }} \
             --json headRepositoryOwner,headRepository \
@@ -106,8 +120,8 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: x-access-token
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
           RELEASE_TRACKER: ${{ github.event.issue.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
               exit 0
           }
 
-          hub pr checkout ${{ github.event.issue.number }}
+          gh pr checkout ${{ github.event.issue.number }}
 
           release-automaton release run \
             --release-tracker=${{ github.event.issue.html_url }} \


### PR DESCRIPTION
## Summary

Tighten the GitHub Actions workflows in this repo so they no longer depend on a long-lived `LGTM_GITHUB_TOKEN` PAT, and bring them in line with GitHub's hardening guidance.

- **Use the default `GITHUB_TOKEN` instead of a PAT** for in-repo operations. `GITHUB_USER` switches to `github.actor`.
- **Scope `GITHUB_TOKEN` to least privilege** at the job level. `release-tracker.yml` gets `contents: write` so the token can push commits/tags back to this repo.
- **Pin every action to a full-length commit SHA** with a trailing version comment, so floating tags like `@v4` can't be silently re-pointed.
- **Tag-triggered workflows** now check out with `fetch-depth: 1` + `fetch-tags: true` so the tag ref resolves without a full clone.
- **Bump outdated `actions/checkout@v1`** to `@v4.3.1` where it appeared.

## Test plan
- [ ] CI passes on this PR.
- [ ] Confirm `release-tracker` continues to push commits/tags on PR close.
- [ ] Confirm `release.yml` still functions on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)